### PR TITLE
4-oesnuj

### DIFF
--- a/oesnuj/README.md
+++ b/oesnuj/README.md
@@ -4,4 +4,5 @@
 |:----:|:---------:|:----:|:-----:|:----:|
 | 1차시 | 2024.03.26 |  스택  | [후위표기식2](https://www.acmicpc.net/problem/1935)  | [#4](https://github.com/AlgoLeadMe/AlgoLeadMe-10/pull/4) |
 | 2차시 | 2024.03.29 |  연결리스트  | [에디터](https://www.acmicpc.net/problem/1406)  | [#8](https://github.com/AlgoLeadMe/AlgoLeadMe-10/pull/8) |
+| 3차시 | 2024.04.02 |  덱  | [카드 놓기](https://www.acmicpc.net/problem/18115)  | [#11](https://github.com/AlgoLeadMe/AlgoLeadMe-10/pull/11) |
 ---

--- a/oesnuj/README.md
+++ b/oesnuj/README.md
@@ -5,4 +5,5 @@
 | 1차시 | 2024.03.26 |  스택  | [후위표기식2](https://www.acmicpc.net/problem/1935)  | [#4](https://github.com/AlgoLeadMe/AlgoLeadMe-10/pull/4) |
 | 2차시 | 2024.03.29 |  연결리스트  | [에디터](https://www.acmicpc.net/problem/1406)  | [#8](https://github.com/AlgoLeadMe/AlgoLeadMe-10/pull/8) |
 | 3차시 | 2024.04.02 |  덱  | [카드 놓기](https://www.acmicpc.net/problem/18115)  | [#11](https://github.com/AlgoLeadMe/AlgoLeadMe-10/pull/11) |
+| 4차시 | 2024.04.06 |  스택  | [옥상 정원 꾸미기](https://www.acmicpc.net/problem/6198)  | [#14](https://github.com/AlgoLeadMe/AlgoLeadMe-10/pull/14) |
 ---

--- a/oesnuj/덱/18115.cpp
+++ b/oesnuj/덱/18115.cpp
@@ -1,0 +1,51 @@
+#include <iostream>
+#include <algorithm>
+#include <deque>
+#include <vector>
+using namespace std;
+
+
+int main()
+{
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+	deque <int> d;
+	vector <int > v;
+	int n;
+	cin >> n;
+	for (int i = 0; i < n; i++) {       //규칙 저장하기 : 사용한 순서대로 vector에 넣음
+		int num;
+		cin >> num;
+		v.push_back(num);
+	}
+	vector<int>::reverse_iterator rit = v.rbegin(); //복원시 가장 마지막에 사용한 규칙부터 사용해야하기에 역반복자 사용
+
+	int card = 1; //다 내려놓은 이후 현재 제일 위의 카드는 1
+	for (rit; rit != v.rend(); rit++) {
+		//규칙 1은 제일 위 카드 1장 바닥에 내려놓기이므로 복원시에는 덱의 가장 위로 옮긴다.
+		if (*rit == 1) 
+			d.push_back(card);
+
+
+		// 규칙 2는 위에 두번째 카드 바닥에 내려놓기이므로 복원시에는 덱의 위에서 두번째로 옮긴다.
+		else if (*rit == 2)
+		{
+			int temp = d.back(); //가장 위의 숫자는 잠깐 빼고
+			d.pop_back();
+			d.push_back(card); //넣어야할 카드 넣고
+			d.push_back(temp); //빼두었던 가장 위의 숫자 다시 넣기
+		}
+
+		//규칙 3은 제일 밑의 카드를 바닥으로 내려놓기이므로 복원시에는 덱의 제일 밑으로 옮긴다.
+		else if (*rit == 3)
+			d.push_front(card);
+		
+		card++; //다음카드를 복원시켜야함(다음카드는 하나 큰 숫자임)
+	}
+
+	reverse(d.begin(), d.end()); //덱의 요소를 뒤(위)에서 부터 출력해야해 뒤집는다.
+	for (auto &k : d) {      //출력
+		cout << k << " ";
+	}
+	return 0;
+}

--- a/oesnuj/스택/6198.cpp
+++ b/oesnuj/스택/6198.cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+int main() {
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+
+	int n;
+	cin >> n; //빌딩 개수 입력
+
+	vector <int> v(n);  //빌딩 높이를 받을 벡터 선언
+	vector <int> s;     //빌딩 높이들을 적절하게 넣을 스택 선언
+	for (auto& i : v)
+		cin >> i;   //각 빌딩 높이 입력
+
+	long long int count = 0;  //count가 int형을 넘어서기에 long long int type으로 둠
+	for (const auto& height : v) // 모든 빌딩 높이를 하나씩 순회한다.
+	{
+		while (true)
+		{
+			if (s.empty()) //스택이 비었다면 현재 빌딩 높이 스택에 push
+			{
+				s.push_back(height);
+				break;
+			}
+			if (height < s.back()) //현재 빌딩 높이가 스택의 top보다 높은 빌딩이라면(볼 수 있는 빌딩이라면)
+			{
+				count += s.size();
+				//스택에는 현재 빌딩보다 높은 빌딩 밖에 없으니 스택의 크기 = 현재 빌딩을 볼 수 있는 빌딩 수
+				s.push_back(height);
+				break;
+			}
+			s.pop_back(); //현재 빌딩이 스택의 top보다 높다면(어짜피 나를 볼 수 없는 빌딩이니) 전부 pop
+			//스택이 비거나 현재 빌딩보다 높은 top이 나올때까지 pop한다.
+			// 언제까지 pop 할까?
+			//case 1. 스택이 비면 나를 볼 수 있는 빌딩은 없다는 뜻이니 스택에 push
+			//case 2. 나보다 높은 빌딩이 나온다면 그때 스택의 크기 = 나를 볼 수 있는 빌딩 수 를 count에 추가
+		}
+	}
+	cout << count;
+	return 0;
+}


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
### 백준 | [옥상 정원 꾸미기](https://www.acmicpc.net/problem/6198)

## ✔️ 소요된 시간
2시간

## ✨ 수도 코드
교황님이 스택 문제로 [탑](https://www.acmicpc.net/problem/2493)을 추천해주셨는데 저번에 풀어본 문제라서 비슷한 문제라고 나와있는 이 문제를 도전했습니다.

먼저 떠오르는 풀이는 각 빌딩의 오른쪽에 자신보다 높은 빌딩 전까지의 원소의 갯수를 다 더하면 답이었습니다.
그런데 이 방법은 최악의 경우O(n제곱)정도의 시간 복잡도를 가져 다른 풀이를 생각해봤습니다.

스택 문제였기에 스택으로 어떻게 풀어야할지 1시간 넘게 고민했네요.
빌딩의 높이를 왼쪽부터 오른쪽으로 하나씩 입력받고 받을때 마다 아래 로직대로 처리를 해줍니다.
흐름대로 설명을 해보자면
>[!Note]
>1. 먼저 스택이 비어있는 상태니까 첫번째 빌딩의 높이를 스택에 넣는다.
>2. 두번째 입력부터 아래 로직을 거치는데
>- 스택에 들어있는 빌딩 높이들 중에 입력받은 빌딩의 높이보다 낮은 빌딩은 다 뺍니다.
>- 낮은 빌딩을 다 뺐다면 스택에는 입렵받은 빌딩보다 높거나 아니면 모두 다 빠져서 비어있을 겁니다.
>- 이때 스택의 남은 빌딩 수가 곧 입력받은 빌딩을 볼 수 있는 빌딩이므로 count에 저장합니다.
>3.위 3단계가 끝나면 스택에 입력받은 빌딩을 스택에 넣어줍니다.

### 🚩예시
건물 5개이고 높이 {10, 5, 1 ,3 ,14}가 순차적으로 입력됩니다.
1. 현재 스택이 비어있으니 현재 입력 `push` 합니다.
Stack
[ 10 ]

2. 두번째 입력 
5보다 낮은 빌딩은 스택에 없다. 스택에 남아있는 빌딩 수가 곧 5를 볼 수 있는 빌딩수(count에 1 더한다.) 
나를 볼 수 있는 빌딩수 처리가 끝났으니 `push`한다.
Stack
[ 10    5 ]

4. 세번째 입력
 1보다 낮은 빌딩은 스택에 없다. 스택에 남아있는 빌딩 수가 곧 1를 볼 수 있는 빌딩수 (count에 2 더한다.) 
나를 볼 수 있는 빌딩수 처리가 끝났으니 `push`한다.
Stack
[ 10    5    1 ]

3. 네번째 입력
 3보다 낮은 빌딩은 스택에 있다. 3보다 낮은 빌딩을 다 `pop` 시킨다. 
Stack
[ 10    5 ] <- 1이 pop, 더 이상 3보다 낮은 빌딩은 없다. 스택에 남아있는 빌딩수가 곧 3을 볼 수 있는 빌딩수 (count 2에 2 더한다.)
나를 볼 수 있는 빌딩수 처리가 끝났으니 `push`한다.
Stack
[ 10    5    3 ]

6. 다섯번째 입력
14보다 낮은 빌딩이 스택에 있다. 14보다 낮은 빌딩을 다 `pop` 시킨다.
Stack
[  ]  <- 3, 5, 10 전부 pop 되어버림. 스택에 남아있는 빌딩수가 없으니 14를 아무도 보지 못한다.
스택이 비었어버렸으니  `push`한다.
Stack
[ 14 ]

---------------------------------------모든 입력이 처리되었다. 이때 count가 정답이된다.

### ⚠주의할 점
이 문제의 입력을 보면 빌딩의 개수 N개가 (1 <= N <= 80,000)입니다.
예를들어 첫번째 빌딩의 높이가 80001, 두번째가 80000, .... N번째가 1이면 볼수 있는 건물의 개수는
80000 + 79999+ 79998 + .... + 1 입니다.
이를 식으로 나타내면 1부터 N까지의 합으로 n(n+1)/2로 n^2입니다.
입력의 최대값인 80000^2는 6,400,000,000이므로 int형이 나타낼 수 있는 범위를 초과합니다.
즉 count 변수를 int 형으로 선언하면 안되고 `long long형`으로 선언해야 합니다.

<details><summary><h2>📂소스코드</h2></summary> 

```cpp
#include <iostream>
#include <vector>

using namespace std;

int main() {
	ios_base::sync_with_stdio(false);
	cin.tie(NULL);

	int n;
	cin >> n; //빌딩 개수 입력

	vector <int> v(n);  //빌딩 높이를 받을 벡터 선언
	vector <int> s;     //빌딩 높이들을 적절하게 넣을 스택 선언
	for (auto& i : v)
		cin >> i;   //각 빌딩 높이 입력

	long long int count = 0;  //count가 int형을 넘어서기에 long long int type으로 둠
	for (const auto& height : v) // 모든 빌딩 높이를 하나씩 순회한다.
	{
		while (true)
		{
			if (s.empty()) //스택이 비었다면 현재 빌딩 높이 스택에 push
			{
				s.push_back(height);
				break;
			}
			if (height < s.back()) //현재 빌딩 높이가 스택의 top보다 높은 빌딩이라면(볼 수 있는 빌딩이라면)
			{
				count += s.size();
				//스택에는 현재 빌딩보다 높은 빌딩 밖에 없으니 스택의 크기 = 현재 빌딩을 볼 수 있는 빌딩 수
				s.push_back(height);
				break;
			}
			s.pop_back(); //현재 빌딩이 스택의 top보다 높다면(어짜피 나를 볼 수 없는 빌딩이니) 전부 pop
			//스택이 비거나 현재 빌딩보다 높은 top이 나올때까지 pop한다.
			// 언제까지 pop 할까?
			//case 1. 스택이 비면 나를 볼 수 있는 빌딩은 없다는 뜻이니 스택에 push
			//case 2. 나보다 높은 빌딩이 나온다면 그때 스택의 크기 = 나를 볼 수 있는 빌딩 수 를 count에 추가
		}
	}
	cout << count;
	return 0;
}
```
</details>


## 📚 새롭게 알게된 내용
문제를 풀때는 내림차순으로 스택의 원소를 구성하면서 로직을 만들자고 푼게 아니고 이것저것 다 생각보고 해보다가 풀고보니 "어 내림차순처럼 스택이 구성되네?" 였습니다. 
다 풀고나서 찾아보니 모노톤 스택이라는 것도 있더라구요.
monotone : 단조로운 
모노톤 스택은 스택의 원소를 중복을 허용하지 않고 오름차순, 또는 내림차순으로 유지시키면서 값을 저장시키는 것 
새 항목이 push 될때 단조를 유지하면서 저장한다. push전에 단조를 유지할 수 있도룩 pop을 수행한다.
이때 정렬되는 과정에서 발생하는 정보들이 유용하다.
이 방식을 이용하면 아까 처음 생각한 풀이와 달리 시간 복잡도가 O(n)인 것을 알 수 있었습니다.
[참고한 사이트](https://iridescentboy.tistory.com/146)

처음은 어찌저찌 구현했지만 스택을 이렇게 활용할 수 있다는 점을 알고 다른 [비슷한 유형](https://www.acmicpc.net/problem/17298)을 풀어보니  쉽게 풀렸습니다.